### PR TITLE
feat: add test and update types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/jest": "27.4.1",
     "jest": "27.5.1",
+    "jest-websocket-mock": "2.3.0",
     "ts-jest": "27.1.4",
     "ts-loader": "9.2.8",
     "typescript": "4.6.3",

--- a/src/ScClient.ts
+++ b/src/ScClient.ts
@@ -1,20 +1,46 @@
 import { invalidValue } from "./errors";
 import { ScAddr } from "./ScAddr";
 import { ScConstruction } from "./ScConstruction";
-import { ScConstructionCommand } from "./ScConstructionCommand";
-import { ScEvent, ScEventCallbackFunc } from "./scEvent";
+import { ScEvent } from "./scEvent";
 import { ScEventParams } from "./ScEventParams";
-import { ScLinkContent, ScLinkContentType } from "./ScLinkContent";
+import {
+  ScLinkContent,
+  ScLinkContentType,
+  TContentString,
+} from "./ScLinkContent";
 import { ScTemplate, ScTemplateTriple, ScTemplateValue } from "./ScTemplate";
-import { ScTemplateSearchResult, ScTemplateResult } from "./ScTemplateResult";
+import { ScTemplateResult } from "./ScTemplateResult";
 import { ScType } from "./scType";
+import {
+  IEdge,
+  ILink,
+  INode,
+  TCheckElementsArgs,
+  TGetContentArgs,
+  TSetContentArgs,
+  TCreateElementsArgs,
+  TDeleteElementsArgs,
+  TWSCallback,
+  TAction,
+  TKeynodesElementsArgs,
+  TTemplateSearchArgs,
+  TTrippleItem,
+  TTemplateGenerateArgs,
+  TCreateEventArgs,
+  TDeleteEventArgs,
+} from "./types";
+import { transformEdgeSide } from "./utils";
 
-type WSCallback = (data: Response) => void;
-
-interface Response<T = any> {
+export interface Response<T = any> {
   id: number;
   status: boolean;
   event: boolean;
+  payload: T;
+}
+
+export interface Request<T = any> {
+  id: number;
+  type: TAction;
   payload: T;
 }
 
@@ -25,24 +51,12 @@ interface KeynodeParam<ParamId extends string = string> {
 
 type SocketEvent = "close" | "error" | "open";
 
-export type ScTemplateGenParams = { [id: string]: ScAddr };
-
-export type TAction =
-  | "create_elements"
-  | "check_elements"
-  | "delete_elements"
-  | "search_template"
-  | "generate_template"
-  | "events"
-  | "keynodes"
-  | "content";
-
 export class ScClient {
   private _eventID: number;
   private _url: string;
   private _messageQueue: Array<() => void>;
   private _socket: WebSocket;
-  private _callbacks: Record<number, WSCallback>;
+  private _callbacks: Record<number, TWSCallback>;
   private _events: Record<number, ScEvent>;
 
   constructor(url: string) {
@@ -70,8 +84,8 @@ export class ScClient {
     this._messageQueue = [];
   };
 
-  private onMessage = (evt: MessageEvent) => {
-    const data = JSON.parse(evt.data);
+  private onMessage = (messageEvent: MessageEvent) => {
+    const data = JSON.parse(messageEvent.data) as Response;
     const cmdID = data.id;
     const callback = this._callbacks[cmdID];
 
@@ -95,15 +109,26 @@ export class ScClient {
 
       delete this._callbacks[cmdID];
 
-      callback(data as Response);
+      callback(data);
     }
   };
 
+  private sendMessage(...args: TDeleteElementsArgs): void;
+  private sendMessage(...args: TCreateElementsArgs): void;
+  private sendMessage(...args: TCheckElementsArgs): void;
+  private sendMessage(...args: TGetContentArgs): void;
+  private sendMessage(...args: TSetContentArgs): void;
+  private sendMessage(...args: TKeynodesElementsArgs): void;
+  private sendMessage(...args: TTemplateSearchArgs): void;
+  private sendMessage(...args: TTemplateGenerateArgs): void;
+  private sendMessage(...args: TCreateEventArgs): void;
+  private sendMessage(...args: TDeleteEventArgs): void;
+
   private sendMessage(
-    type: TAction,
-    payload: Record<string, any>,
-    callback: WSCallback
-  ) {
+    actionType: string,
+    payload: unknown,
+    callback: TWSCallback<any>
+  ): void {
     this._eventID++;
 
     if (this._callbacks[this._eventID]) {
@@ -113,14 +138,15 @@ export class ScClient {
     this._callbacks[this._eventID] = callback;
     const data = JSON.stringify({
       id: this._eventID,
-      type,
+      type: actionType,
       payload,
     });
 
     const sendData = () => this._socket.send(data);
 
     if (this._socket.readyState !== this._socket.OPEN) {
-      return this._messageQueue.push(sendData);
+      this._messageQueue.push(sendData);
+      return;
     }
     sendData();
   }
@@ -131,62 +157,46 @@ export class ScClient {
 
       const payload = addrs.map(({ value }) => value);
 
-      this.sendMessage("check_elements", payload, (data: Response) => {
+      this.sendMessage("check_elements", payload, (data) => {
         const result = data.payload.map((scType: number) => new ScType(scType));
         resolve(result);
       });
     });
   }
 
-  public async createElements(constr: ScConstruction) {
+  public async createElements(construction: ScConstruction) {
     return new Promise<ScAddr[]>((resolve) => {
-      const payload = constr.commands.map((cmd: ScConstructionCommand) => {
-        if (cmd.type.isNode()) {
-          return {
-            el: "node",
-            type: cmd.type.value,
-          };
-        }
-        if (cmd.type.isEdge()) {
-          function solveAdj(obj: any) {
-            if (obj instanceof ScAddr) {
-              return {
-                type: "addr",
-                value: obj.value,
-              };
-            }
-
-            const idx = constr.getIndex(obj);
-            if (idx === undefined) {
-              invalidValue(`Invalid alias: ${obj}`);
-            }
+      const payload = construction.commands
+        .map((cmd) => {
+          if (cmd.type.isNode()) {
             return {
-              type: "ref",
-              value: idx,
+              el: "node",
+              type: cmd.type.value,
+            };
+          }
+          if (cmd.type.isEdge()) {
+            return {
+              el: "edge",
+              type: cmd.type.value,
+              src: transformEdgeSide(construction, cmd.data.src),
+              trg: transformEdgeSide(construction, cmd.data.trg),
+            };
+          }
+          if (cmd.type.isLink()) {
+            return {
+              el: "link",
+              type: cmd.type.value,
+              content: cmd.data.content,
+              content_type: cmd.data.type,
             };
           }
 
-          return {
-            el: "edge",
-            type: cmd.type.value,
-            src: solveAdj(cmd.data.src),
-            trg: solveAdj(cmd.data.trg),
-          };
-        }
-        if (cmd.type.isLink()) {
-          return {
-            el: "link",
-            type: cmd.type.value,
-            content: cmd.data.content,
-            content_type: cmd.data.type,
-          };
-        }
+          invalidValue("Unknown type");
+        })
+        .filter((value): value is INode | IEdge | ILink => Boolean(value));
 
-        invalidValue("Unknown type");
-      });
-
-      this.sendMessage("create_elements", payload, (data: Response) => {
-        resolve(data.payload.map((a: number) => new ScAddr(a)));
+      this.sendMessage("create_elements", payload, (data) => {
+        resolve(data.payload.map((a) => new ScAddr(a)));
       });
     });
   }
@@ -194,7 +204,7 @@ export class ScClient {
   public async deleteElements(addrs: ScAddr[]) {
     return new Promise<boolean>((resolve) => {
       const payload = addrs.map(({ value }) => value);
-      this.sendMessage("delete_elements", payload, (data: Response) => {
+      this.sendMessage("delete_elements", payload, (data) => {
         resolve(data.status);
       });
     });
@@ -202,16 +212,14 @@ export class ScClient {
 
   public async setLinkContents(contents: ScLinkContent[]) {
     return new Promise<boolean[]>((resolve) => {
-      const payload = contents.map((content) => {
-        return {
-          command: "set",
-          type: content.typeToStr(),
-          data: content.data,
-          addr: content.addr?.value,
-        };
-      });
+      const payload = contents.map((content) => ({
+        command: "set" as const,
+        type: content.typeToStr(),
+        data: content.data,
+        addr: content.addr?.value as number,
+      }));
 
-      this.sendMessage("content", payload, (data: Response) => {
+      this.sendMessage("content", payload, (data) => {
         resolve(data.payload);
       });
     });
@@ -219,27 +227,21 @@ export class ScClient {
 
   public async getLinkContents(addrs: ScAddr[]) {
     return new Promise<ScLinkContent[]>((resolve) => {
-      const payload = addrs.map(({ value }) => {
-        return {
-          command: "get",
-          addr: value,
-        };
-      });
+      const payload = addrs.map(({ value }) => ({
+        command: "get" as const,
+        addr: value,
+      }));
 
-      this.sendMessage("content", payload, (data: Response) => {
-        const result: ScLinkContent[] = data.payload.map((o: any) => {
-          const t: string = o["type"];
-          let ctype = ScLinkContentType.Binary;
-          if (t == "string") {
-            ctype = ScLinkContentType.String;
-          } else if (t == "int") {
-            ctype = ScLinkContentType.Int;
-          } else if (t == "float") {
-            ctype = ScLinkContentType.Float;
-          }
-
-          return new ScLinkContent(o["value"], ctype);
-        });
+      this.sendMessage("content", payload, (data) => {
+        const result = data.payload
+          .filter(
+            (res): res is { value: string | number; type: TContentString } =>
+              !!res.value
+          )
+          .map(
+            ({ type, value }) =>
+              new ScLinkContent(value, ScLinkContent.stringToType(type))
+          );
 
         resolve(result);
       });
@@ -253,124 +255,96 @@ export class ScClient {
       const payload = params.map(({ id, type }) => {
         if (type.isValid()) {
           return {
-            command: "resolve",
+            command: "resolve" as const,
             idtf: id,
             elType: type.value,
           };
         }
 
         return {
-          command: "find",
+          command: "find" as const,
           idtf: id,
         };
       });
 
-      this.sendMessage("keynodes", payload, (data: Response) => {
+      this.sendMessage("keynodes", payload, (data) => {
         const addrs = data.payload.map((addr: number) => new ScAddr(addr));
 
-        const result = {} as Record<ParamId, ScAddr>;
-        for (let i = 0; i < addrs.length; ++i) {
-          result[params[i].id] = addrs[i];
-        }
+        const result = addrs.reduce(
+          (acc, curr, ind) => ({
+            ...acc,
+            [params[ind].id]: curr,
+          }),
+          {} as Record<ParamId, ScAddr>
+        );
+
         resolve(result);
       });
     });
   }
 
-  private processTripleItem(it: ScTemplateValue) {
-    let result: any = {};
-    if (it.value instanceof ScAddr) {
-      result = { type: "addr", value: it.value.value };
-    } else if (it.value instanceof ScType) {
-      result = { type: "type", value: it.value.value };
-    } else {
-      return { type: "alias", value: it.value };
+  private processTripleItem({ value, alias }: ScTemplateValue): TTrippleItem {
+    const aliasObj = alias ? { alias } : {};
+    if (value instanceof ScAddr) {
+      return { type: "addr", value: value.value, ...aliasObj };
     }
-
-    if (it.alias) {
-      result.alias = it.alias;
+    if (value instanceof ScType) {
+      return { type: "type", value: value.value, ...aliasObj };
     }
-
-    return result;
+    return { type: "alias", value, ...aliasObj };
   }
 
-  public async templateSearch(templ: ScTemplate | string) {
-    return new Promise<ScTemplateSearchResult>(async (resolve) => {
-      let payload: any = [];
+  public async templateSearch(template: ScTemplate | string) {
+    return new Promise<ScTemplateResult[]>(async (resolve) => {
+      const payload =
+        typeof template === "string"
+          ? template
+          : template.triples.map(({ source, edge, target }) => [
+              this.processTripleItem(source),
+              this.processTripleItem(edge),
+              this.processTripleItem(target),
+            ]);
 
-      if (typeof templ === "string") {
-        payload = templ;
-      } else {
-        templ.forEachSearchTriple((triple: ScTemplateTriple) => {
-          let items: object[] = [];
-          payload.push([
-            this.processTripleItem(triple.source),
-            this.processTripleItem(triple.edge),
-            this.processTripleItem(triple.target),
-          ]);
+      this.sendMessage("search_template", payload, ({ payload, status }) => {
+        if (!status) return resolve([]);
+
+        const result = payload.addrs.map((addrs) => {
+          const templateAddrs = addrs.map((addr) => new ScAddr(addr));
+          return new ScTemplateResult(payload.aliases, templateAddrs);
         });
-      }
-
-      this.sendMessage("search_template", payload, (data: Response) => {
-        let result: ScTemplateSearchResult = [];
-        if (data.status) {
-          const aliases: any = data.payload["aliases"];
-          const addrs: number[][] = data.payload["addrs"];
-
-          addrs.forEach((addrsItem: number[]) => {
-            let resultAddrsItem: ScAddr[] = [];
-            addrsItem.forEach((a: number) => {
-              resultAddrsItem.push(new ScAddr(a));
-            });
-            result.push(new ScTemplateResult(aliases, resultAddrsItem));
-          });
-        }
-
         resolve(result);
       });
     });
   }
 
   public async templateGenerate(
-    templ: ScTemplate | string,
-    params: ScTemplateGenParams
+    template: ScTemplate | string,
+    params: Record<string, ScAddr>
   ) {
     return new Promise<ScTemplateResult | null>(async (resolve) => {
-      let templData: any = [];
+      const templ =
+        typeof template === "string"
+          ? template
+          : template.triples.map(({ source, edge, target }) => [
+              this.processTripleItem(source),
+              this.processTripleItem(edge),
+              this.processTripleItem(target),
+            ]);
 
-      if (typeof templ === "string") {
-        templData = templ;
-      } else {
-        templ.forEachSearchTriple((triple: ScTemplateTriple) => {
-          templData.push([
-            this.processTripleItem(triple.source),
-            this.processTripleItem(triple.edge),
-            this.processTripleItem(triple.target),
-          ]);
-        });
-      }
-      const jsonParams = {} as Record<string, any>;
-      for (let key in params) {
-        if (params.hasOwnProperty(key)) {
-          jsonParams[key] = params[key].value;
-        }
-      }
-      const payload = { templ: templData, params: jsonParams };
+      const numericParams = Object.keys(params).reduce(
+        (acc, key) => ({
+          ...acc,
+          [key]: params[key].value,
+        }),
+        {} as Record<string, number>
+      );
 
-      this.sendMessage("generate_template", payload, (data: Response) => {
-        if (data.status) {
-          const aliases: any = data.payload["aliases"];
-          const addrs: number[] = data.payload["addrs"];
+      const payload = { templ, params: numericParams };
 
-          let resultAddrs: ScAddr[] = [];
-          addrs.forEach((a) => {
-            resultAddrs.push(new ScAddr(a));
-          });
-
-          resolve(new ScTemplateResult(aliases, resultAddrs));
-        }
-
-        resolve(null);
+      this.sendMessage("generate_template", payload, ({ status, payload }) => {
+        if (!status) resolve(null);
+        const addrs = payload.addrs.map((addr) => new ScAddr(addr));
+        resolve(new ScTemplateResult(payload.aliases, addrs));
       });
     });
   }
@@ -388,7 +362,7 @@ export class ScClient {
         })),
       };
 
-      this.sendMessage("events", payload, (data: Response<number[]>) => {
+      this.sendMessage("events", payload, (data) => {
         const result = events.map(({ callback, type }, ind) => {
           const eventId = data.payload[ind];
           const newEvt = new ScEvent(eventId, type, callback);

--- a/src/ScClient.ts
+++ b/src/ScClient.ts
@@ -1,16 +1,12 @@
 import { invalidValue } from "./errors";
 import { ScAddr } from "./ScAddr";
 import { ScConstruction } from "./ScConstruction";
-import { ScEvent } from "./scEvent";
+import { ScEvent } from "./ScEvent";
 import { ScEventParams } from "./ScEventParams";
-import {
-  ScLinkContent,
-  ScLinkContentType,
-  TContentString,
-} from "./ScLinkContent";
+import { ScLinkContent, TContentString } from "./ScLinkContent";
 import { ScTemplate, ScTemplateTriple, ScTemplateValue } from "./ScTemplate";
 import { ScTemplateResult } from "./ScTemplateResult";
-import { ScType } from "./scType";
+import { ScType } from "./ScType";
 import {
   IEdge,
   ILink,
@@ -24,12 +20,12 @@ import {
   TAction,
   TKeynodesElementsArgs,
   TTemplateSearchArgs,
-  TTrippleItem,
+  TTripleItem,
   TTemplateGenerateArgs,
   TCreateEventArgs,
   TDeleteEventArgs,
 } from "./types";
-import { transformEdgeSide } from "./utils";
+import { transformEdgeInfo } from "./utils";
 
 export interface Response<T = any> {
   id: number;
@@ -158,7 +154,7 @@ export class ScClient {
       const payload = addrs.map(({ value }) => value);
 
       this.sendMessage("check_elements", payload, (data) => {
-        const result = data.payload.map((scType: number) => new ScType(scType));
+        const result = data.payload.map((type: number) => new ScType(type));
         resolve(result);
       });
     });
@@ -178,8 +174,8 @@ export class ScClient {
             return {
               el: "edge",
               type: cmd.type.value,
-              src: transformEdgeSide(construction, cmd.data.src),
-              trg: transformEdgeSide(construction, cmd.data.trg),
+              src: transformEdgeInfo(construction, cmd.data.src),
+              trg: transformEdgeInfo(construction, cmd.data.trg),
             };
           }
           if (cmd.type.isLink()) {
@@ -283,7 +279,7 @@ export class ScClient {
     });
   }
 
-  private processTripleItem({ value, alias }: ScTemplateValue): TTrippleItem {
+  private processTripleItem({ value, alias }: ScTemplateValue): TTripleItem {
     const aliasObj = alias ? { alias } : {};
     if (value instanceof ScAddr) {
       return { type: "addr", value: value.value, ...aliasObj };

--- a/src/ScConstruction.ts
+++ b/src/ScConstruction.ts
@@ -1,6 +1,6 @@
 import { ScAddr } from "./ScAddr";
 import { ScLinkContent } from "./ScLinkContent";
-import { ScType } from "./scType";
+import { ScType } from "./ScType";
 import { invalidValue } from "./errors";
 import { ScConstructionCommand } from "./ScConstructionCommand";
 

--- a/src/ScConstructionCommand.ts
+++ b/src/ScConstructionCommand.ts
@@ -1,4 +1,4 @@
-import { ScType } from "./scType";
+import { ScType } from "./ScType";
 
 export class ScConstructionCommand {
   private _elType: ScType;

--- a/src/ScEventParams.ts
+++ b/src/ScEventParams.ts
@@ -1,5 +1,5 @@
 import { ScAddr } from "./ScAddr";
-import { ScEventCallbackFunc, ScEventType } from "./scEvent";
+import { ScEventCallbackFunc, ScEventType } from "./ScEvent";
 
 export class ScEventParams {
   private _addr: ScAddr;

--- a/src/ScLinkContent.ts
+++ b/src/ScLinkContent.ts
@@ -7,6 +7,8 @@ export enum ScLinkContentType {
   Binary = 3,
 }
 
+export type TContentString = "binary" | "float" | "int" | "string";
+
 export class ScLinkContent {
   private _data: string | number;
   private _type: ScLinkContentType;
@@ -28,7 +30,7 @@ export class ScLinkContent {
     return this._addr;
   }
 
-  public typeToStr() {
+  public typeToStr(): TContentString {
     switch (this._type) {
       case ScLinkContentType.Binary:
         return "binary";
@@ -38,6 +40,19 @@ export class ScLinkContent {
         return "int";
       default:
         return "string";
+    }
+  }
+
+  public static stringToType(string: TContentString): ScLinkContentType {
+    switch (string) {
+      case "binary":
+        return ScLinkContentType.Binary;
+      case "float":
+        return ScLinkContentType.Float;
+      case "int":
+        return ScLinkContentType.Int;
+      default:
+        return ScLinkContentType.String;
     }
   }
 }

--- a/src/ScSet.ts
+++ b/src/ScSet.ts
@@ -1,10 +1,10 @@
 import { ScAddr } from "./ScAddr";
 import { ScClient } from "./ScClient";
-import { ScEvent, ScEventType } from "./scEvent";
+import { ScEvent, ScEventType } from "./ScEvent";
 import { ScEventParams } from "./ScEventParams";
 import { ScTemplate } from "./ScTemplate";
 import { ScTemplateResult } from "./ScTemplateResult";
-import { ScType } from "./scType";
+import { ScType } from "./ScType";
 
 export type CallbackAddElement = (addr: ScAddr) => Promise<void>;
 export type CallbackRemoveElement = (addr: ScAddr) => Promise<void>;

--- a/src/ScSet.ts
+++ b/src/ScSet.ts
@@ -3,7 +3,7 @@ import { ScClient } from "./ScClient";
 import { ScEvent, ScEventType } from "./scEvent";
 import { ScEventParams } from "./ScEventParams";
 import { ScTemplate } from "./ScTemplate";
-import { ScTemplateSearchResult, ScTemplateResult } from "./ScTemplateResult";
+import { ScTemplateResult } from "./ScTemplateResult";
 import { ScType } from "./scType";
 
 export type CallbackAddElement = (addr: ScAddr) => Promise<void>;
@@ -218,8 +218,7 @@ export class ScSet {
       [el, "_item"]
     );
 
-    const searchRes: ScTemplateSearchResult =
-      await this._scClient.templateSearch(templ);
+    const searchRes = await this._scClient.templateSearch(templ);
     if (searchRes.length == 0) {
       const genRes = await this._scClient.templateGenerate(templ, {
         _item: el,

--- a/src/ScTemplate.ts
+++ b/src/ScTemplate.ts
@@ -28,6 +28,10 @@ export interface ScTemplateTriple {
 export class ScTemplate {
   private _triples: ScTemplateTriple[] = [];
 
+  get triples() {
+    return this._triples;
+  }
+
   // internal usage only
   public forEachSearchTriple(callback: (triple: ScTemplateTriple) => void) {
     this._triples.forEach((tripple) => {

--- a/src/ScTemplate.ts
+++ b/src/ScTemplate.ts
@@ -1,5 +1,5 @@
 import { ScAddr } from "./ScAddr";
-import { ScType } from "./scType";
+import { ScType } from "./ScType";
 
 type ScTemplateParamValue = string | ScAddr | ScType;
 type ScTemplateParam = ScTemplateParamValue[] | ScTemplateParamValue;
@@ -30,13 +30,6 @@ export class ScTemplate {
 
   get triples() {
     return this._triples;
-  }
-
-  // internal usage only
-  public forEachSearchTriple(callback: (triple: ScTemplateTriple) => void) {
-    this._triples.forEach((tripple) => {
-      callback(tripple);
-    });
   }
 
   public triple(

--- a/src/ScTemplateResult.ts
+++ b/src/ScTemplateResult.ts
@@ -1,20 +1,16 @@
 import { ScAddr } from "./ScAddr";
 
-// Result of template search
-type ScValueIndex = { [id: string]: number };
 type ScTripleCallback = (src: ScAddr, edge: ScAddr, trg: ScAddr) => void;
-
-export type ScTemplateSearchResult = ScTemplateResult[];
-export type ScTemplateGenerateResult = ScTemplateResult;
 
 export class ScTemplateResult {
   private _addrs: ScAddr[] = [];
-  private _indecies: ScValueIndex = {};
+  private _indecies: Record<string, number> = {};
 
-  constructor(indecies: ScValueIndex, addrs: ScAddr[]) {
+  constructor(indecies: Record<string, number>, addrs: ScAddr[]) {
     this._indecies = indecies;
     this._addrs = addrs;
   }
+
   public get size() {
     return this._addrs.length;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,168 @@
+import { ScEventType } from "./scEvent";
+import { ScLinkContentType, TContentString } from "./ScLinkContent";
+
+export interface IContentResult {
+  value: number | string | null;
+  type: TContentString;
+}
+
+interface ISetContentPayload {
+  command: "set";
+  type: TContentString;
+  data: string | number;
+  addr: number;
+}
+
+interface IGetContentPayload {
+  command: "get";
+  addr: number;
+}
+
+interface IFindKeynode {
+  command: "find";
+  idtf: string;
+}
+
+interface IResolveKeynode {
+  command: "resolve";
+  idtf: string;
+  elType: number;
+}
+
+type TKeynodesPayload = Array<IFindKeynode | IResolveKeynode>;
+
+export interface INode {
+  el: "node";
+  type: number;
+}
+
+export interface IEdgeSide {
+  type: "addr" | "ref";
+  value: number;
+}
+
+export interface IEdge {
+  el: "edge";
+  type: number;
+  src: IEdgeSide;
+  trg: IEdgeSide;
+}
+
+export interface ILink {
+  el: "link";
+  type: number;
+  content: string | number;
+  content_type: ScLinkContentType;
+}
+
+interface ITrippleAddr {
+  type: "addr";
+  value: number;
+  alias?: string;
+}
+
+interface ITrippleType {
+  type: "type";
+  value: number;
+  alias?: string;
+}
+
+interface ITrippleAlias {
+  type: "alias";
+  value: string;
+  alias?: string;
+}
+
+export type TTrippleItem = ITrippleAddr | ITrippleType | ITrippleAlias;
+
+type TSearchTemplatePayload = TTrippleItem[][] | string;
+
+interface IGenerateTemplatePayload {
+  templ: TTrippleItem[][] | string;
+  params: Record<string, number>;
+}
+
+interface ICreateEventPayload {
+  create: Array<{ type: ScEventType; addr: number }>;
+}
+
+interface IDeleteEventPayload {
+  delete: number[];
+}
+
+interface ISearchResult {
+  aliases: Record<string, number>;
+  addrs: number[][];
+}
+
+interface IGenerateResult {
+  aliases: Record<string, number>;
+  addrs: number[];
+}
+
+export interface Response<
+  Payload extends unknown = unknown,
+  Event extends boolean = boolean
+> {
+  id: number;
+  status: boolean;
+  event: Event;
+  payload: Payload;
+}
+
+export type TAction =
+  | "create_elements"
+  | "check_elements"
+  | "delete_elements"
+  | "search_template"
+  | "generate_template"
+  | "events"
+  | "keynodes"
+  | "content";
+
+export type TWSCallback<
+  Payload extends unknown = unknown,
+  Event extends boolean = boolean
+> = (data: Response<Payload, Event>) => void;
+
+type Args<
+  Action extends TAction,
+  Payload extends unknown,
+  ResponsePayload extends unknown,
+  Event extends boolean = boolean
+> = [Action, Payload, TWSCallback<ResponsePayload, Event>];
+
+export type TCheckElementsArgs = Args<"check_elements", number[], number[]>;
+export type TDeleteElementsArgs = Args<"delete_elements", number[], unknown>;
+export type TKeynodesElementsArgs = Args<
+  "keynodes",
+  TKeynodesPayload,
+  number[]
+>;
+export type TTemplateSearchArgs = Args<
+  "search_template",
+  TSearchTemplatePayload,
+  ISearchResult
+>;
+export type TTemplateGenerateArgs = Args<
+  "generate_template",
+  IGenerateTemplatePayload,
+  IGenerateResult
+>;
+export type TCreateEventArgs = Args<"events", ICreateEventPayload, number[]>;
+export type TDeleteEventArgs = Args<"events", IDeleteEventPayload, number[]>;
+export type TCreateElementsArgs = Args<
+  "create_elements",
+  Array<ILink | IEdge | INode>,
+  number[]
+>;
+export type TSetContentArgs = Args<
+  "content",
+  Array<ISetContentPayload>,
+  [boolean]
+>;
+export type TGetContentArgs = Args<
+  "content",
+  Array<IGetContentPayload>,
+  IContentResult[]
+>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { ScEventType } from "./scEvent";
+import { ScEventType } from "./ScEvent";
 import { ScLinkContentType, TContentString } from "./ScLinkContent";
 
 export interface IContentResult {
@@ -36,7 +36,7 @@ export interface INode {
   type: number;
 }
 
-export interface IEdgeSide {
+interface IEdgeInfo {
   type: "addr" | "ref";
   value: number;
 }
@@ -44,8 +44,8 @@ export interface IEdgeSide {
 export interface IEdge {
   el: "edge";
   type: number;
-  src: IEdgeSide;
-  trg: IEdgeSide;
+  src: IEdgeInfo;
+  trg: IEdgeInfo;
 }
 
 export interface ILink {
@@ -55,30 +55,30 @@ export interface ILink {
   content_type: ScLinkContentType;
 }
 
-interface ITrippleAddr {
+interface ITripleAddr {
   type: "addr";
   value: number;
   alias?: string;
 }
 
-interface ITrippleType {
+interface ITripleType {
   type: "type";
   value: number;
   alias?: string;
 }
 
-interface ITrippleAlias {
+interface ITripleAlias {
   type: "alias";
   value: string;
   alias?: string;
 }
 
-export type TTrippleItem = ITrippleAddr | ITrippleType | ITrippleAlias;
+export type TTripleItem = ITripleAddr | ITripleType | ITripleAlias;
 
-type TSearchTemplatePayload = TTrippleItem[][] | string;
+type TSearchTemplatePayload = TTripleItem[][] | string;
 
 interface IGenerateTemplatePayload {
-  templ: TTrippleItem[][] | string;
+  templ: TTripleItem[][] | string;
   params: Record<string, number>;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { invalidValue } from "./errors";
 import { ScAddr } from "./ScAddr";
 import { ScConstruction } from "./ScConstruction";
 
-export const transformEdgeSide = (
+export const transformEdgeInfo = (
   construction: ScConstruction,
   aliasOrAddr: ScAddr | string
 ) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,26 @@
+import { invalidValue } from "./errors";
+import { ScAddr } from "./ScAddr";
+import { ScConstruction } from "./ScConstruction";
+
+export const transformEdgeSide = (
+  construction: ScConstruction,
+  aliasOrAddr: ScAddr | string
+) => {
+  if (typeof aliasOrAddr !== "string") {
+    return {
+      type: "addr",
+      value: aliasOrAddr.value,
+    };
+  }
+
+  const aliasIndex = construction.getIndex(aliasOrAddr);
+
+  if (aliasIndex === undefined) {
+    return invalidValue(`Invalid alias: ${aliasIndex}`);
+  }
+
+  return {
+    type: "ref",
+    value: aliasIndex,
+  };
+};

--- a/tests/scClient.test.ts
+++ b/tests/scClient.test.ts
@@ -1,77 +1,387 @@
 import { ScAddr } from "../src/ScAddr";
 import { ScClient } from "../src/ScClient";
 import { ScConstruction } from "../src/ScConstruction";
-import { ScEventType } from "../src/scEvent";
-import { ScEventParams } from "../src/ScEventParams";
 import { ScType } from "../src/ScType";
+import WS from "jest-websocket-mock";
+import { ScLinkContent, ScLinkContentType } from "../src/ScLinkContent";
+import { ScTemplate } from "../src/ScTemplate";
+import { ScEvent, ScEventType } from "../src/scEvent";
+import { ScEventParams } from "../src/ScEventParams";
+import { setupServer } from "./utils";
+import { ScTemplateResult } from "../src/ScTemplateResult";
 
-const URL = "";
-
-const baseKeynodes = [
-  { id: "action_get_dialog", type: ScType.NodeConstClass },
-] as const;
+const URL = "ws://localhost:1234";
 
 describe("ScClient", () => {
   let client: ScClient;
+  let server: WS;
 
-  beforeAll(() => {
+  beforeEach(async () => {
+    server = new WS(URL, { jsonProtocol: true });
+
+    setupServer(server);
     client = new ScClient(URL);
+
+    await server.connected;
+  });
+
+  afterEach(() => {
+    WS.clean();
   });
 
   test("createElements", async () => {
+    const myNode = "_node";
+    const myLink = "_link";
+
+    const linkContent = "my_content";
+    const fakeNodeAddr = new ScAddr(123);
+
     const construction = new ScConstruction();
 
-    construction.createNode(ScType.NodeConst);
+    construction.createNode(ScType.NodeConst, myNode);
+    construction.createLink(
+      ScType.LinkConst,
+      new ScLinkContent(linkContent, ScLinkContentType.String),
+      myLink
+    );
+    construction.createEdge(
+      ScType.EdgeAccessConstPosPerm,
+      myNode,
+      fakeNodeAddr
+    );
 
     const res = await client.createElements(construction);
 
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(3);
+    res.forEach((resItem) => expect(resItem).toBeInstanceOf(ScAddr));
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "create_elements",
+        payload: expect.arrayContaining([
+          {
+            el: "node",
+            type: ScType.NodeConst.value,
+          },
+          {
+            el: "link",
+            type: ScType.LinkConst.value,
+            content: linkContent,
+            content_type: ScLinkContentType.String,
+          },
+          {
+            el: "edge",
+            src: {
+              type: "ref",
+              value: 0,
+            },
+            trg: {
+              type: "addr",
+              value: fakeNodeAddr.value,
+            },
+            type: ScType.EdgeAccessConstPosPerm.value,
+          },
+        ]),
+      })
+    );
   });
 
-  test("createElementsWithAlias", async () => {
-    const construction = new ScConstruction();
+  test("deleteElements", async () => {
+    const fakeNodeAddr1 = new ScAddr(123);
+    const fakeNodeAddr2 = new ScAddr(12223);
 
-    construction.createNode(ScType.NodeConst, "myAlias1");
-    construction.createNode(ScType.NodeConst, "myAlias2");
-    construction.createEdge(ScType.EdgeDCommonConst, "myAlias1", "myAlias2");
+    const res = await client.deleteElements([fakeNodeAddr1, fakeNodeAddr2]);
 
-    const res = await client.createElements(construction);
-    expect(res.length).toBe(3);
+    expect(res).toBeTruthy();
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "delete_elements",
+        payload: expect.arrayContaining([
+          fakeNodeAddr1.value,
+          fakeNodeAddr2.value,
+        ]),
+      })
+    );
   });
 
-  test("deleteElements & checkElements", async () => {
-    const construction = new ScConstruction();
+  test("checkElements", async () => {
+    const fakeNodeAddr1 = new ScAddr(123);
+    const fakeNodeAddr2 = new ScAddr(12223);
 
-    construction.createNode(ScType.NodeConst, "myAlias");
+    const res = await client.checkElements([fakeNodeAddr1, fakeNodeAddr2]);
 
-    const createRes = await client.createElements(construction);
-    expect(createRes.length).toBe(1);
+    expect(res).toHaveLength(2);
+    res.forEach((resItem) => expect(resItem).toBeInstanceOf(ScType));
 
-    const checkResAfterCreate = await client.checkElements(createRes);
-    expect(checkResAfterCreate.length).toBe(1);
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "check_elements",
+        payload: expect.arrayContaining([
+          fakeNodeAddr1.value,
+          fakeNodeAddr2.value,
+        ]),
+      })
+    );
+  });
 
-    const deleteRes = await client.deleteElements(createRes);
-    expect(deleteRes).toBeTruthy();
+  test("setContent", async () => {
+    const content = "my_content";
+    const linkContent = new ScLinkContent(content, ScLinkContentType.String);
 
-    const checkResAfterDelete = await client.checkElements(createRes);
-    checkResAfterDelete.forEach((scAddr) => {
-      expect(scAddr.isValid()).toBeFalsy();
-    });
+    const res = await client.setLinkContents([linkContent]);
+
+    expect(res).toHaveLength(1);
+    expect(res[0]).toBeTruthy();
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "content",
+        payload: expect.arrayContaining([
+          {
+            command: "set",
+            type: "string",
+            data: content,
+          },
+        ]),
+      })
+    );
+  });
+
+  test("getContent", async () => {
+    const fakeNodeAddr = new ScAddr(123);
+
+    const res = await client.getLinkContents([fakeNodeAddr]);
+
+    expect(res).toHaveLength(1);
+    expect(res[0]).toBeInstanceOf(ScLinkContent);
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "content",
+        payload: expect.arrayContaining([
+          {
+            command: "get",
+            addr: fakeNodeAddr.value,
+          },
+        ]),
+      })
+    );
   });
 
   test("resolveKeynodes", async () => {
-    const res = await client.resolveKeynodes(baseKeynodes);
-    expect(res["action_get_dialog"].isValid()).toBeTruthy();
+    const id1 = "id1";
+    const id2 = "id2";
+
+    const keynodes = [
+      { id: id1, type: ScType.EdgeDCommon },
+      { id: id2, type: new ScType() },
+    ];
+
+    const res = await client.resolveKeynodes(keynodes);
+
+    expect(res).toEqual({
+      [id1]: expect.any(ScAddr),
+      [id2]: expect.any(ScAddr),
+    });
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "keynodes",
+        payload: expect.arrayContaining([
+          { command: "resolve", idtf: id1, elType: ScType.EdgeDCommon.value },
+          { command: "find", idtf: id2 },
+        ]),
+      })
+    );
   });
 
-  test("createEvent", async () => {
-    const evtParams = new ScEventParams(
-      new ScAddr(),
-      ScEventType.AddIngoingEdge,
-      async (_subscibedAddr, _arc, _anotherAddr, eventId) => {
-        await client.eventsDestroy([eventId]);
-      }
+  test("templateSearch", async () => {
+    const fakeAddr1 = new ScAddr(123);
+    const fakeAddr2 = new ScAddr(1232333);
+
+    const circuitDialogAlias = "_circuit_dialog";
+    const dialog = "_dialog";
+
+    const template = new ScTemplate();
+
+    template.tripleWithRelation(
+      fakeAddr1,
+      ScType.EdgeDCommonVar,
+      [ScType.NodeVarStruct, circuitDialogAlias],
+      ScType.EdgeAccessVarPosPerm,
+      fakeAddr2
     );
-    const res = await client.eventsCreate(evtParams);
+    template.triple(circuitDialogAlias, ScType.EdgeAccessVarPosPerm, [
+      ScType.NodeVar,
+      dialog,
+    ]);
+
+    const res = await client.templateSearch(template);
+
+    res.forEach((resItem) => expect(resItem).toBeInstanceOf(ScTemplateResult));
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "search_template",
+        payload: expect.arrayContaining([
+          expect.arrayContaining([
+            { type: "addr", value: fakeAddr1.value },
+            {
+              alias: expect.any(String),
+              type: "type",
+              value: ScType.EdgeDCommonVar.value,
+            },
+            {
+              alias: circuitDialogAlias,
+              type: "type",
+              value: ScType.NodeVarStruct.value,
+            },
+          ]),
+          expect.arrayContaining([
+            { type: "addr", value: fakeAddr2.value },
+            { type: "type", value: ScType.EdgeAccessVarPosPerm.value },
+            { type: "alias", value: expect.any(String) },
+          ]),
+          expect.arrayContaining([
+            { type: "alias", value: circuitDialogAlias },
+            { type: "type", value: ScType.EdgeAccessVarPosPerm.value },
+            { alias: dialog, type: "type", value: ScType.NodeVar.value },
+          ]),
+        ]),
+      })
+    );
+  });
+
+  test("templateGenerate", async () => {
+    const fakeAddr1 = new ScAddr(123);
+    const fakeAddr2 = new ScAddr(1232333);
+
+    const fakeParamAddr = new ScAddr(777);
+
+    const circuitDialogAlias = "_circuit_dialog";
+    const dialog = "_dialog";
+
+    const template = new ScTemplate();
+
+    template.tripleWithRelation(
+      fakeAddr1,
+      ScType.EdgeDCommonVar,
+      [ScType.NodeVarStruct, circuitDialogAlias],
+      ScType.EdgeAccessVarPosPerm,
+      fakeAddr2
+    );
+    template.triple(circuitDialogAlias, ScType.EdgeAccessVarPosPerm, [
+      ScType.NodeVar,
+      dialog,
+    ]);
+
+    const params = {
+      [dialog]: fakeParamAddr,
+    };
+
+    const res = await client.templateGenerate(template, params);
+
+    expect(res).toBeInstanceOf(ScTemplateResult);
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "generate_template",
+        payload: expect.objectContaining({
+          templ: expect.arrayContaining([
+            expect.arrayContaining([
+              { type: "addr", value: fakeAddr1.value },
+              {
+                alias: expect.any(String),
+                type: "type",
+                value: ScType.EdgeDCommonVar.value,
+              },
+              {
+                alias: circuitDialogAlias,
+                type: "type",
+                value: ScType.NodeVarStruct.value,
+              },
+            ]),
+            expect.arrayContaining([
+              { type: "addr", value: fakeAddr2.value },
+              { type: "type", value: ScType.EdgeAccessVarPosPerm.value },
+              { type: "alias", value: expect.any(String) },
+            ]),
+            expect.arrayContaining([
+              { type: "alias", value: circuitDialogAlias },
+              { type: "type", value: ScType.EdgeAccessVarPosPerm.value },
+              { alias: dialog, type: "type", value: ScType.NodeVar.value },
+            ]),
+          ]),
+          params: {
+            [dialog]: fakeParamAddr.value,
+          },
+        }),
+      })
+    );
+  });
+
+  test("eventsCreate", async () => {
+    const eventCallback = jest.fn();
+
+    const fakeAddr1 = new ScAddr(123);
+    const fakeAddr2 = new ScAddr(12311);
+
+    const evtParams1 = new ScEventParams(
+      fakeAddr1,
+      ScEventType.AddIngoingEdge,
+      eventCallback
+    );
+    const evtParams2 = new ScEventParams(
+      fakeAddr2,
+      ScEventType.RemoveIngoingEdge,
+      () => void 0
+    );
+
+    const res = await client.eventsCreate([evtParams1, evtParams2]);
+
+    res.forEach((resItem) => expect(resItem).toBeInstanceOf(ScEvent));
+
+    expect(eventCallback).toHaveBeenCalledWith(
+      expect.any(ScAddr),
+      expect.any(ScAddr),
+      expect.any(ScAddr),
+      expect.any(Number)
+    );
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "events",
+        payload: expect.objectContaining({
+          create: expect.arrayContaining([
+            {
+              type: ScEventType.AddIngoingEdge,
+              addr: fakeAddr1.value,
+            },
+            {
+              type: ScEventType.RemoveIngoingEdge,
+              addr: fakeAddr2.value,
+            },
+          ]),
+        }),
+      })
+    );
+  });
+
+  test("eventsDestroy", async () => {
+    const eventIds = [1, 2];
+
+    const res = await client.eventsDestroy(eventIds);
+
+    expect(res).toBe(undefined);
+
+    await expect(server).toReceiveMessage(
+      expect.objectContaining({
+        type: "events",
+        payload: expect.objectContaining({
+          delete: expect.arrayContaining(eventIds),
+        }),
+      })
+    );
   });
 });

--- a/tests/scClient.test.ts
+++ b/tests/scClient.test.ts
@@ -5,7 +5,7 @@ import { ScType } from "../src/ScType";
 import WS from "jest-websocket-mock";
 import { ScLinkContent, ScLinkContentType } from "../src/ScLinkContent";
 import { ScTemplate } from "../src/ScTemplate";
-import { ScEvent, ScEventType } from "../src/scEvent";
+import { ScEvent, ScEventType } from "../src/ScEvent";
 import { ScEventParams } from "../src/ScEventParams";
 import { setupServer } from "./utils";
 import { ScTemplateResult } from "../src/ScTemplateResult";

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from "../src/ScClient";
+import WS from "jest-websocket-mock";
+
+const EVENT_ID = 7;
+
+const getMockAnswerPayload = (data: Request) => {
+  if (data.type === "create_elements") {
+    return data.payload.map((_: any, ind: number) => ind);
+  }
+  if (data.type === "check_elements") {
+    return data.payload.map((_: any, ind: number) => ind);
+  }
+  if (data.type === "content") {
+    return data.payload.map(({ command }: { command: "set" | "get" }) =>
+      command === "set" ? true : { value: "12345", type: "string" }
+    );
+  }
+  if (data.type === "keynodes") {
+    return data.payload.map((_: any, ind: number) => ind + 1);
+  }
+  if (["search_template", "generate_template"].includes(data.type)) {
+    return {
+      aliases: {},
+      addrs: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+    };
+  }
+  if (data.type === "events") {
+    return [EVENT_ID];
+  }
+  return [];
+};
+
+export const setupServer = (server: WS) => {
+  server.on("connection", (socket) => {
+    socket.on(
+      "message",
+      (JSONdata: string | Blob | ArrayBuffer | ArrayBufferView) => {
+        if (typeof JSONdata !== "string") return;
+
+        const data = JSON.parse(JSONdata) as Request;
+        const dataToSend: Response = {
+          id: data.id,
+          status: true,
+          event: false,
+          payload: getMockAnswerPayload(data),
+        };
+
+        server.send(dataToSend);
+        if (data.type === "events" && !data.payload.delete) {
+          server.send({
+            id: EVENT_ID,
+            status: true,
+            event: true,
+            payload: [1, 2, 3],
+          });
+        }
+      }
+    );
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1751,7 +1751,7 @@ jest-config@^27.5.1:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^27.5.1:
+jest-diff@^27.0.2, jest-diff@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
   integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
@@ -2056,6 +2056,14 @@ jest-watcher@^27.5.1:
     jest-util "^27.5.1"
     string-length "^4.0.1"
 
+jest-websocket-mock@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/jest-websocket-mock/-/jest-websocket-mock-2.3.0.tgz#317e7d7f8ba54ba632a7300777b02b7ebb606845"
+  integrity sha512-kXhRRApRdT4hLG/4rhsfcR0Ke0OzqIsDj0P5t0dl5aiAftShSgoRqp/0pyjS5bh+b9GrIzmfkrV2cn9LxxvSvA==
+  dependencies:
+    jest-diff "^27.0.2"
+    mock-socket "^9.1.0"
+
 jest-worker@^27.4.5, jest-worker@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
@@ -2257,6 +2265,11 @@ minimatch@^3.0.4:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+mock-socket@^9.1.0:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.1.3.tgz#bcb106c6b345001fa7619466fcf2f8f5a156b10f"
+  integrity sha512-uz8lx8c5wuJYJ21f5UtovqpV0+KJuVwE7cVOLNhrl2QW/CvmstOLRfjXnLSbfFHZtJtiaSGQu0oCJA8SmRcK6A==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
This PR adds unit tests for ScClient using jest testing library, jest-websocket-mock and custom mock server implementation.
Also types were updated. Now every sendMessage call knows the input and output structure based on action type.
In the end some code refactoring was done.